### PR TITLE
Add Chopsticks integration for Ganache-like testing

### DIFF
--- a/src/commands/node/chopsticks/init.ts
+++ b/src/commands/node/chopsticks/init.ts
@@ -11,7 +11,7 @@ import { SwankyConfig } from "../../../types/index.js";
 export const chopsticksConfig = "dev.yml";
 
 export class InitChopsticks extends SwankyCommand<typeof InitChopsticks> {
-  static description = "Initialize Zombienet";
+  static description = "Initialize chopsticks config";
 
   async run(): Promise<void> {
     const localConfig = getSwankyConfig("local") as SwankyConfig;

--- a/src/commands/node/chopsticks/init.ts
+++ b/src/commands/node/chopsticks/init.ts
@@ -1,0 +1,42 @@
+import path from "node:path";
+import { SwankyCommand } from "../../../lib/swankyCommand.js";
+import {
+  buildZombienetConfigFromBinaries, copyChopsticksTemplateFile,
+  copyZombienetTemplateFile,
+  downloadZombienetBinaries, getSwankyConfig,
+  getTemplates,
+} from "../../../lib/index.js";
+import { ConfigBuilder } from "../../../lib/config-builder.js";
+import { SwankyConfig } from "../../../types/index.js";
+
+export const chopsticksConfig = "dev.yml";
+
+export class InitChopsticks extends SwankyCommand<typeof InitChopsticks> {
+  static description = "Initialize Zombienet";
+
+  async run(): Promise<void> {
+    const {} = await this.parse(InitChopsticks);
+
+    const localConfig = getSwankyConfig("local") as SwankyConfig;
+    const projectPath = path.resolve();
+
+    const chopsticksTemplatePath = getTemplates().chopsticksTemplatesPath;
+    const configPath = path.resolve(projectPath, "node", "config");
+
+    await this.spinner.runCommand(
+      () =>
+        copyChopsticksTemplateFile(chopsticksTemplatePath, configPath),
+      "Copying template files",
+    );
+
+    await this.spinner.runCommand(async () => {
+      const newLocalConfig = new ConfigBuilder(localConfig)
+        .addChopsticks(path.resolve(projectPath, "node", "config", chopsticksConfig))
+        .build();
+      await this.storeConfig(newLocalConfig, "local");
+    }, "Writing config");
+
+    this.log("Chopsticks config initialized successfully");
+  }
+}
+

--- a/src/commands/node/chopsticks/init.ts
+++ b/src/commands/node/chopsticks/init.ts
@@ -14,8 +14,6 @@ export class InitChopsticks extends SwankyCommand<typeof InitChopsticks> {
   static description = "Initialize Zombienet";
 
   async run(): Promise<void> {
-    const {} = await this.parse(InitChopsticks);
-
     const localConfig = getSwankyConfig("local") as SwankyConfig;
     const projectPath = path.resolve();
 

--- a/src/commands/node/chopsticks/init.ts
+++ b/src/commands/node/chopsticks/init.ts
@@ -1,9 +1,8 @@
 import path from "node:path";
 import { SwankyCommand } from "../../../lib/swankyCommand.js";
 import {
-  buildZombienetConfigFromBinaries, copyChopsticksTemplateFile,
-  copyZombienetTemplateFile,
-  downloadZombienetBinaries, getSwankyConfig,
+  copyChopsticksTemplateFile,
+  getSwankyConfig,
   getTemplates,
 } from "../../../lib/index.js";
 import { ConfigBuilder } from "../../../lib/config-builder.js";

--- a/src/commands/node/chopsticks/init.ts
+++ b/src/commands/node/chopsticks/init.ts
@@ -23,7 +23,7 @@ export class InitChopsticks extends SwankyCommand<typeof InitChopsticks> {
     await this.spinner.runCommand(
       () =>
         copyChopsticksTemplateFile(chopsticksTemplatePath, configPath),
-      "Copying template files",
+      "Copying Chopsticks template files...",
     );
 
     await this.spinner.runCommand(async () => {
@@ -31,7 +31,7 @@ export class InitChopsticks extends SwankyCommand<typeof InitChopsticks> {
         .addChopsticks(path.resolve(projectPath, "node", "config", chopsticksConfig))
         .build();
       await this.storeConfig(newLocalConfig, "local");
-    }, "Writing config");
+    }, "Updating Swanky configuration with Chopsticks settings...");
 
     this.log("Chopsticks config initialized successfully");
   }

--- a/src/commands/node/chopsticks/start.ts
+++ b/src/commands/node/chopsticks/start.ts
@@ -1,9 +1,8 @@
 import { Flags } from "@oclif/core";
 import { execaCommand } from "execa";
 import { SwankyCommand } from "../../../lib/swankyCommand.js";
-import semver from "semver";
 import { swankyNodeCheck } from "../../../lib/index.js";
-import { pathExists, pathExistsSync } from "fs-extra/esm";
+import { pathExistsSync } from "fs-extra/esm";
 import { ConfigError, FileError } from "../../../lib/errors.js";
 export class StartChopsticks extends SwankyCommand<typeof StartChopsticks> {
   static description = "Start chopsticks";

--- a/src/commands/node/chopsticks/start.ts
+++ b/src/commands/node/chopsticks/start.ts
@@ -1,7 +1,7 @@
 import { Flags } from "@oclif/core";
 import { execaCommand } from "execa";
 import { SwankyCommand } from "../../../lib/swankyCommand.js";
-import { swankyNodeCheck } from "../../../lib/index.js";
+import { ensureSwankyNodeInstalled } from "../../../lib/index.js";
 import { pathExists } from "fs-extra/esm";
 import { ConfigError, FileError } from "../../../lib/errors.js";
 export class StartChopsticks extends SwankyCommand<typeof StartChopsticks> {
@@ -16,7 +16,7 @@ export class StartChopsticks extends SwankyCommand<typeof StartChopsticks> {
   async run(): Promise<void> {
     const { flags } = await this.parse(StartChopsticks);
 
-    swankyNodeCheck(this.swankyConfig);
+    ensureSwankyNodeInstalled(this.swankyConfig);
 
     const chopsticksConfigPath = flags.config ?? this.swankyConfig.node.chopsticks?.configPath;
 

--- a/src/commands/node/chopsticks/start.ts
+++ b/src/commands/node/chopsticks/start.ts
@@ -1,0 +1,39 @@
+import { Flags } from "@oclif/core";
+import { execaCommand } from "execa";
+import { SwankyCommand } from "../../../lib/swankyCommand.js";
+import semver from "semver";
+import { swankyNodeCheck } from "../../../lib/index.js";
+import { pathExists, pathExistsSync } from "fs-extra/esm";
+import { ConfigError, FileError } from "../../../lib/errors.js";
+export class StartChopsticks extends SwankyCommand<typeof StartChopsticks> {
+  static description = "Start chopsticks";
+
+  static flags = {
+    "config": Flags.string({
+      description: "Path to the chopsticks config file",
+    })
+  }
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(StartChopsticks);
+
+    swankyNodeCheck(this.swankyConfig);
+
+    if(!this.swankyConfig.node.chopsticks && !flags.chopsticksConfigPath) {
+      throw new ConfigError("Chopsticks config not set in swanky config. Please set it in swanky config or provide the path to the chopsticks config file using --config flag.");
+    }
+
+    if (flags.chopsticksConfigPath && !pathExistsSync(flags.chopsticksConfigPath)) {
+      throw new FileError(`Chopsticks config file not found at ${flags.chopsticksConfigPath}`);
+    }
+
+    await execaCommand(
+      `npx @acala-network/chopsticks@latest --config=${flags.chopsticksConfigPath ?? this.swankyConfig.node.chopsticks!.configPath}`,
+      {
+        stdio: "inherit",
+      }
+    );
+
+    this.log("Chopsticks started");
+  }
+}

--- a/src/commands/node/chopsticks/start.ts
+++ b/src/commands/node/chopsticks/start.ts
@@ -35,6 +35,6 @@ export class StartChopsticks extends SwankyCommand<typeof StartChopsticks> {
       }
     );
 
-    this.log("Chopsticks started");
+    this.log("Chopsticks started successfully.");
   }
 }

--- a/src/commands/node/chopsticks/start.ts
+++ b/src/commands/node/chopsticks/start.ts
@@ -2,7 +2,7 @@ import { Flags } from "@oclif/core";
 import { execaCommand } from "execa";
 import { SwankyCommand } from "../../../lib/swankyCommand.js";
 import { swankyNodeCheck } from "../../../lib/index.js";
-import { pathExistsSync } from "fs-extra/esm";
+import { pathExists } from "fs-extra/esm";
 import { ConfigError, FileError } from "../../../lib/errors.js";
 export class StartChopsticks extends SwankyCommand<typeof StartChopsticks> {
   static description = "Start chopsticks";
@@ -18,16 +18,18 @@ export class StartChopsticks extends SwankyCommand<typeof StartChopsticks> {
 
     swankyNodeCheck(this.swankyConfig);
 
-    if(!this.swankyConfig.node.chopsticks && !flags.chopsticksConfigPath) {
+    const chopsticksConfigPath = flags.config ?? this.swankyConfig.node.chopsticks?.configPath;
+
+    if(!chopsticksConfigPath) {
       throw new ConfigError("Chopsticks config not set in swanky config. Please set it in swanky config or provide the path to the chopsticks config file using --config flag.");
     }
 
-    if (flags.chopsticksConfigPath && !pathExistsSync(flags.chopsticksConfigPath)) {
-      throw new FileError(`Chopsticks config file not found at ${flags.chopsticksConfigPath}`);
+    if (!(await pathExists(chopsticksConfigPath))) {
+      throw new FileError(`Chopsticks config file not found at ${flags.config}`);
     }
 
     await execaCommand(
-      `npx @acala-network/chopsticks@latest --config=${flags.chopsticksConfigPath ?? this.swankyConfig.node.chopsticks!.configPath}`,
+      `npx @acala-network/chopsticks@latest --config=${chopsticksConfigPath}`,
       {
         stdio: "inherit",
       }

--- a/src/commands/node/start.ts
+++ b/src/commands/node/start.ts
@@ -2,7 +2,7 @@ import { Flags } from "@oclif/core";
 import { execaCommand } from "execa";
 import { SwankyCommand } from "../../lib/swankyCommand.js";
 import semver from "semver";
-import { swankyNodeCheck } from "../../lib/index.js";
+import { ensureSwankyNodeInstalled } from "../../lib/index.js";
 export class StartNode extends SwankyCommand<typeof StartNode> {
   static description = "Start a local node";
 
@@ -30,7 +30,7 @@ export class StartNode extends SwankyCommand<typeof StartNode> {
   async run(): Promise<void> {
     const { flags } = await this.parse(StartNode);
 
-    swankyNodeCheck(this.swankyConfig);
+    ensureSwankyNodeInstalled(this.swankyConfig);
 
     // Run persistent mode by default. non-persistent mode in case flag is provided.
     // Non-Persistent mode (`--dev`) allows all CORS origin, without `--dev`, users need to specify origins by `--rpc-cors`.

--- a/src/commands/node/start.ts
+++ b/src/commands/node/start.ts
@@ -2,6 +2,7 @@ import { Flags } from "@oclif/core";
 import { execaCommand } from "execa";
 import { SwankyCommand } from "../../lib/swankyCommand.js";
 import semver from "semver";
+import { swankyNodeCheck } from "../../lib/index.js";
 export class StartNode extends SwankyCommand<typeof StartNode> {
   static description = "Start a local node";
 
@@ -29,9 +30,8 @@ export class StartNode extends SwankyCommand<typeof StartNode> {
   async run(): Promise<void> {
     const { flags } = await this.parse(StartNode);
 
-    if(this.swankyConfig.node.localPath === "") {
-      this.error("Swanky node is not installed. Please run `swanky node:install` first.");
-    }
+    swankyNodeCheck(this.swankyConfig);
+
     // Run persistent mode by default. non-persistent mode in case flag is provided.
     // Non-Persistent mode (`--dev`) allows all CORS origin, without `--dev`, users need to specify origins by `--rpc-cors`.
     await execaCommand(

--- a/src/lib/command-utils.ts
+++ b/src/lib/command-utils.ts
@@ -43,7 +43,6 @@ export function getSwankyConfig(configType: "local" | "global"): SwankyConfig | 
   return config;
 }
 
-
 export function getSystemConfigDirectoryPath(): string {
   const homeDir = userInfo().homedir;
   const configPath = homeDir + `/${DEFAULT_CONFIG_FOLDER_NAME}`;
@@ -148,12 +147,14 @@ export async function generateTypes(contractName: string) {
   );
 }
 export function ensureAccountIsSet(account: string | undefined, config: SwankyConfig) {
-  if(!account && config.defaultAccount === null) {
-    throw new ConfigError("No default account set. Please set one or provide an account alias with --account");
+  if (!account && config.defaultAccount === null) {
+    throw new ConfigError(
+      "No default account set. Please set one or provide an account alias with --account"
+    );
   }
 }
 
-export function buildSwankyConfig() { 
+export function buildSwankyConfig() {
   return {
     node: {
       localPath: "",
@@ -164,16 +165,16 @@ export function buildSwankyConfig() {
     defaultAccount: DEFAULT_ACCOUNT,
     accounts: [
       {
-        "alias": "alice",
-        "mnemonic": "//Alice",
-        "isDev": true,
-        "address": "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
+        alias: "alice",
+        mnemonic: "//Alice",
+        isDev: true,
+        address: "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
       },
       {
-        "alias": "bob",
-        "mnemonic": "//Bob",
-        "isDev": true,
-        "address": "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty"
+        alias: "bob",
+        mnemonic: "//Bob",
+        isDev: true,
+        address: "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",
       },
     ],
     networks: {
@@ -249,5 +250,14 @@ export function extractCargoDylintVersion() {
 }
 
 export function extractCargoContractVersion() {
-  return extractVersion("cargo contract -V", /cargo-contract-contract (\d+\.\d+\.\d+(?:-[\w.]+)?)(?:-unknown-[\w-]+)/);
+  return extractVersion(
+    "cargo contract -V",
+    /cargo-contract-contract (\d+\.\d+\.\d+(?:-[\w.]+)?)(?:-unknown-[\w-]+)/
+  );
+}
+
+export function swankyNodeCheck(config: SwankyConfig) {
+  if (config.node.localPath === "") {
+    throw new FileError("Swanky node is not installed. Please run `swanky node:install` first.");
+  }
 }

--- a/src/lib/command-utils.ts
+++ b/src/lib/command-utils.ts
@@ -255,9 +255,3 @@ export function extractCargoContractVersion() {
     /cargo-contract-contract (\d+\.\d+\.\d+(?:-[\w.]+)?)(?:-unknown-[\w-]+)/
   );
 }
-
-export function swankyNodeCheck(config: SwankyConfig) {
-  if (config.node.localPath === "") {
-    throw new FileError("Swanky node is not installed. Please run `swanky node:install` first.");
-  }
-}

--- a/src/lib/config-builder.ts
+++ b/src/lib/config-builder.ts
@@ -78,6 +78,15 @@ export class ConfigBuilder<T extends SwankySystemConfig | SwankyConfig> {
     return this;
   }
 
+  addChopsticks(path: string): ConfigBuilder<T> {
+    if("node" in this.config) {
+      this.config.node.chopsticks ={
+        configPath: path,
+      }
+    }
+    return this;
+  }
+
   build(): T {
     return this.config;
   }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,0 +1,8 @@
+import { SwankyConfig } from "../index.js";
+import { FileError } from "./errors.js";
+
+export function ensureSwankyNodeInstalled(config: SwankyConfig) {
+    if (config.node.localPath === "") {
+        throw new FileError('Swanky node is not installed. Please run `swanky node:install` first.');
+    }
+}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,5 +1,6 @@
 export * from "./account.js";
 export * from "./command-utils.js";
+export * from "./config.js";
 export * as consts from "./consts.js";
 export * from "./crypto.js";
 export * from "./nodeInfo.js";

--- a/src/lib/tasks.ts
+++ b/src/lib/tasks.ts
@@ -17,6 +17,7 @@ import { zombienetConfig } from "../commands/zombienet/init.js";
 import { readFileSync } from "fs";
 import TOML from "@iarna/toml";
 import { writeFileSync } from "node:fs";
+import { chopsticksConfig } from "../commands/node/chopsticks/init.js";
 
 export async function checkCliDependencies(spinner: Spinner) {
   const dependencyList = [
@@ -215,6 +216,14 @@ export async function copyZombienetTemplateFile(templatePath: string, configPath
   await copy(
     path.resolve(templatePath, zombienetConfig),
     path.resolve(configPath, zombienetConfig),
+  );
+}
+
+export async function copyChopsticksTemplateFile(templatePath: string, configPath: string) {
+  await ensureDir(configPath);
+  await copy(
+    path.resolve(templatePath, chopsticksConfig),
+    path.resolve(configPath, chopsticksConfig),
   );
 }
 

--- a/src/lib/templates.ts
+++ b/src/lib/templates.ts
@@ -9,6 +9,7 @@ export function getTemplates() {
   const templatesPath = path.resolve(__dirname, "..", "templates");
   const contractTemplatesPath = path.resolve(templatesPath, "contracts");
   const zombienetTemplatesPath = path.resolve(templatesPath, "zombienet");
+  const chopsticksTemplatesPath = path.resolve(templatesPath, "chopsticks");
   const fileList = readdirSync(contractTemplatesPath, {
     withFileTypes: true,
   });
@@ -21,5 +22,6 @@ export function getTemplates() {
     contractTemplatesPath,
     contractTemplatesList,
     zombienetTemplatesPath,
+    chopsticksTemplatesPath,
   };
 }

--- a/src/templates/chopsticks/dev.yml
+++ b/src/templates/chopsticks/dev.yml
@@ -1,0 +1,4 @@
+endpoint: ws://127.0.0.1:9944
+mock-signature-host: true
+block: 1
+db: ./db.sqlite

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -58,6 +58,9 @@ export interface SwankyConfig extends SwankySystemConfig{
     localPath: string;
     supportedInk: string;
     version: string;
+    chopsticks?: {
+      configPath: string;
+    };
   };
   contracts: Record<string, ContractData> | Record<string, never>;
   zombienet?: ZombienetData;


### PR DESCRIPTION
This PR are connected to [Ganache-like testing feature #49](https://github.com/inkdevhub/swanky-node/issues/49). The main purpose of this issue is to make testing easier by implementing next features:
> * block time stamp manipulation (can mine a block with arbitrary block time stamp)
> * block number manipulation
> * taking a snapshot and retrieve later
> * Balance manipulation of accounts
> * Impersonate any account

All of them can already implemented in [Chopsticks](https://github.com/AcalaNetwork/chopsticks). Below I will explain how to use it.
Firstly, you should set up your swanky project with `swanky init` and choose that you want to install swanky-node. Then you should use `swanky node chopsticks init` to initiate chopsticks config, which will be stored in the `./node/config/` folder. Then you start the node(`swanky node start`) and fork it with chopsticks(`swanky node chopsticks start`). 
Now we have a testing node that has all the features that we need. Chopsticks allow to use of different RPC calls. Full list of them you can check [here](https://acalanetwork.github.io/chopsticks/docs/chopsticks/README.html).
For example, you can do timestamp manipulation by `dev_timeTravel' RPC call:
```TypeScript
import { WsProvider } from '@polkadot/rpc-provider'
const ws = new WsProvider(`ws://localhost:8000`)
await ws.send('dev_timeTravel', ['Jan 1, 2023'])
```
Or go back to any block by 'dev_setHead':
```TypeScript
import { WsProvider } from '@polkadot/rpc-provider'
const ws = new WsProvider(`ws://localhost:8000`)
await ws.send('dev_setHead', [1000000])
```
